### PR TITLE
Fix fetch_price docstring typo

### DIFF
--- a/avg_crypto_price.py
+++ b/avg_crypto_price.py
@@ -71,7 +71,7 @@ def fetch_price(coin: str, session: requests.Session):
         coin (str): coin name
         session (requests.Session): Requests session for HTTP calls.
     Raises:
-        Exception: log Network execption every 5 retries else break
+        Exception: log Network exception every 5 retries else break
     Returns:
         price, formatted_timestamp: return price of coin and timestamp
     """


### PR DESCRIPTION
## Summary
- fix minor typo in `fetch_price` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684560f3c2d883239328d630770f4a43